### PR TITLE
Add NETRC env var

### DIFF
--- a/src/netrc.ts
+++ b/src/netrc.ts
@@ -181,7 +181,7 @@ export class Netrc {
           process.env.USERPROFILE)) ||
       os.homedir() ||
       os.tmpdir()
-    let file = path.join(home, os.platform() === 'win32' ? '_netrc' : '.netrc')
+    let file = process.env.NETRC || path.join(home, os.platform() === 'win32' ? '_netrc' : '.netrc')
     return fs.existsSync(file + '.gpg') ? (file += '.gpg') : file
   }
 

--- a/test/netrc.test.ts
+++ b/test/netrc.test.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import * as fs from 'fs-extra'
+import * as path from 'path'
 
 import {Netrc} from '../src/netrc'
 
@@ -41,6 +42,21 @@ machine ray login demo password mypassword`,
 
     expect(netrc.machines.ray.login).to.equal('demo')
     expect(netrc.machines.ray.password).to.equal('mypassword')
+  })
+
+  it('can read netrc via NETRC env var', async () => {
+    const originalNetrcEnv = process.env.NETRC
+    process.env.NETRC = path.resolve(__dirname, '../tmp/.netrc')
+    let netrc = new Netrc()
+    await netrc.load()
+
+    expect(netrc.machines['mail.google.com'].login).to.equal('joe@gmail.com')
+    expect(netrc.machines['mail.google.com'].account).to.equal('gmail')
+    expect(netrc.machines['mail.google.com'].password).to.equal('somethingSecret')
+
+    expect(netrc.machines.ray.login).to.equal('demo')
+    expect(netrc.machines.ray.password).to.equal('mypassword')
+    process.env.NETRC = originalNetrcEnv
   })
 
   it('bad default order', () => {


### PR DESCRIPTION
There is a need in the heroku cli to be able to change the location of the netrc file location without changing the home directory. This follows the same design as mentioned [here](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html#:~:text=netrc%20file-,The%20.,the%20command%20line%20option%20%2DN%20.):
>  It generally resides in the user’s home directory, but a location outside of the home directory can be set using the environment variable NETRC

@jdxcode What do you think about adding this feature?